### PR TITLE
Initial support for calling out to vLLM server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       - ./data:/data
     stdin_open: true
     tty: true
+    network_mode: "host"
     # networks:
     #   - isolated_network
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ compressed-tensors
 
 # Added for ovis quantized models
 # gptqmodel
+
+# For vLLM OpenAI client
+vllm
+openai

--- a/src/main.py
+++ b/src/main.py
@@ -72,149 +72,159 @@ def main(args):
         logging.info("Logging in to the Hugging Face Hub")
         huggingface_hub.login(token=os.environ["HF_TOKEN"])
 
-    # Initialize model
-    if args.model.startswith("apriel"):
-        model = vlm_models.Apriel_1_5_Model(
+    if args.openai_api_base_url:
+        logging.info(f"Using vLLM OpenAI API client")
+        model = vlm_models.VLLM_OpenAI_Client(
             checkpoint=args.model,
             system_prompt=system_prompt,
             prompt=user_prompt,
-            quantize=args.quantize,
-            thinking=args.thinking,
-        )
-    elif args.model.startswith("blip2"):
-        model = vlm_models.Blip2Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("deepseek-vl2"):
-        from vlm_models import deepseekvl2
-
-        model = deepseekvl2.DeepSeekVL2Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("instructblip"):
-        model = vlm_models.InstructBlipModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("internvl2"):
-        model = vlm_models.InternVL2Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("internvl3"):
-        model = vlm_models.InternVL3Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-            thinking=args.thinking,
-        )
-    elif args.model.startswith("joycaption"):
-        model = vlm_models.JoyCaptionModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("kimi-vl"):
-        # model = vlm_models.Kimi_VL_Model(
-        #     checkpoint=args.model,
-        #     system_prompt=system_prompt,
-        #     prompt=user_prompt,
-        #     quantize=args.quantize,
-        # )
-        raise Exception("computer says no")
-    elif args.model.startswith("minicpm"):
-        model = vlm_models.MiniCPM_V_2_6(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("ovis1.6"):
-        from vlm_models import Ovis1_6Model
-        
-        model = vlm_models.Ovis1_6Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("ovis2"):
-        '''
-        model = vlm_models.Ovis2Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-        '''
-    elif args.model.startswith("paligemma2"):
-        from vlm_models import pali_gemma2
-
-        model = pali_gemma2.PaliGemma2Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("phi"):
-        model = vlm_models.PhiModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("qwen2.5-vl"):
-        model = vlm_models.Qwen2_5VLModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("qwen3-vl"):
-        model = vlm_models.Qwen3_VL_Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("revisual-r1"):
-        model = vlm_models.RevisualR1Model(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("wepoints"):
-        from vlm_models import wepoints
-
-        model = wepoints.WePOINTSModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-        )
-    elif args.model.startswith("yannqi-r"):
-        model = vlm_models.YannQiRModel(
-            checkpoint=args.model,
-            system_prompt=system_prompt,
-            prompt=user_prompt,
-            quantize=args.quantize,
-            thinking=args.thinking,
+            openai_api_key=args.openai_api_key,
+            openai_api_base_url=args.openai_api_base_url,
         )
     else:
-        raise ValueError(f"Unsupported model type: {args.model}")
+        # Initialize model
+        if args.model.startswith("apriel"):
+            model = vlm_models.Apriel_1_5_Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+                thinking=args.thinking,
+            )
+        elif args.model.startswith("blip2"):
+            model = vlm_models.Blip2Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("deepseek-vl2"):
+            from vlm_models import deepseekvl2
+
+            model = deepseekvl2.DeepSeekVL2Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("instructblip"):
+            model = vlm_models.InstructBlipModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("internvl2"):
+            model = vlm_models.InternVL2Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("internvl3") or args.model.startswith("neo1_0"):
+            model = vlm_models.InternVL3Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+                thinking=args.thinking,
+            )
+        elif args.model.startswith("joycaption"):
+            model = vlm_models.JoyCaptionModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("kimi-vl"):
+            # model = vlm_models.Kimi_VL_Model(
+            #     checkpoint=args.model,
+            #     system_prompt=system_prompt,
+            #     prompt=user_prompt,
+            #     quantize=args.quantize,
+            # )
+            raise Exception("computer says no")
+        elif args.model.startswith("minicpm"):
+            model = vlm_models.MiniCPM_V_2_6(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("ovis1.6"):
+            from vlm_models import Ovis1_6Model
+            
+            model = vlm_models.Ovis1_6Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("ovis2"):
+            '''
+            model = vlm_models.Ovis2Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+            '''
+        elif args.model.startswith("paligemma2"):
+            from vlm_models import pali_gemma2
+
+            model = pali_gemma2.PaliGemma2Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("phi"):
+            model = vlm_models.PhiModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("qwen2.5-vl"):
+            model = vlm_models.Qwen2_5VLModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("qwen3-vl"):
+            model = vlm_models.Qwen3_VL_Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("revisual-r1"):
+            model = vlm_models.RevisualR1Model(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("wepoints"):
+            from vlm_models import wepoints
+
+            model = wepoints.WePOINTSModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+            )
+        elif args.model.startswith("yannqi-r"):
+            model = vlm_models.YannQiRModel(
+                checkpoint=args.model,
+                system_prompt=system_prompt,
+                prompt=user_prompt,
+                quantize=args.quantize,
+                thinking=args.thinking,
+            )
+        else:
+            raise ValueError(f"Unsupported model type: {args.model}")
 
     output_base_dir = "/data/output/"
     output_dir = output_base_dir + model.checkpoint_name()
@@ -284,6 +294,12 @@ def parse_args():
     import argparse
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--openai_api_key", type=str, help="API key for OpenAI API client"
+    )
+    parser.add_argument(
+        "--openai_api_base_url", type=str, help="Base URL for OpenAI API client"
+    )
     parser.add_argument(
         "--model", type=str, default="internvl3", help="Model type to use"
     )

--- a/src/vlm_models/__init__.py
+++ b/src/vlm_models/__init__.py
@@ -13,6 +13,7 @@ from .phi import PhiModel
 from .qwen2_5 import Qwen2_5VLModel
 from .qwen3 import Qwen3_VL_Model
 from .revisual_r1 import RevisualR1Model
+from .vllm_openai_client import VLLM_OpenAI_Client
 from .yannqi_r import YannQiRModel
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "Qwen2_5VLModel",
     "Qwen3_VL_Model",
     "RevisualR1Model",
+    "VLLM_OpenAI_Client",
     "YannQiRModel",
 ]

--- a/src/vlm_models/base_model.py
+++ b/src/vlm_models/base_model.py
@@ -6,7 +6,7 @@ import math
 
 
 class BaseVLMModel(ABC):
-    def __init__(self, checkpoint: str, system_prompt: str, prompt: str, quantize: bool):
+    def __init__(self, checkpoint: str, system_prompt: str, prompt: str, quantize: bool = False):
         self.checkpoint = checkpoint
         self.query = self._process_query(system_prompt, prompt)
         self.quantize = quantize

--- a/src/vlm_models/vllm_openai_client.py
+++ b/src/vlm_models/vllm_openai_client.py
@@ -1,0 +1,79 @@
+import copy
+from PIL import Image
+from openai import OpenAI
+import base64
+from io import BytesIO
+
+from vlm_models.base_model import BaseVLMModel
+
+
+class VLLM_OpenAI_Client(BaseVLMModel):
+    def __init__(
+        self,
+        system_prompt: str,
+        prompt: str,
+        checkpoint: str,
+        openai_api_key: str,
+        openai_api_base_url: str,
+    ):
+        self.client = OpenAI(
+            api_key=openai_api_key,
+            base_url=openai_api_base_url,
+        )
+        super().__init__(
+            checkpoint,
+            system_prompt,
+            prompt,
+        )
+        self.system_prompt = system_prompt
+        self.user_prompt = prompt
+        self.supports_batch = False
+
+    def _initialize_model(self):
+        pass
+
+    def _encode_image_to_data_uri(self, image: Image.Image, format: str) -> str:
+        """
+        Encodes a PIL Image object into a Base64 Data URI string.
+        """
+        buffered = BytesIO()
+        image.save(buffered, format=format)
+        image_bytes = buffered.getvalue()
+
+        base64_encoded_image = base64.b64encode(image_bytes).decode("utf-8")
+
+        mime_type = f"image/{format.lower()}"
+        data_uri = f"data:{mime_type};base64,{base64_encoded_image}"
+        return data_uri
+
+    def _process_query(self, system_prompt: str, prompt: str):
+        pass
+
+    def _preprocess_image(self, img_path: str):
+        image = Image.open(img_path).convert("RGB")
+        image = super().downscale_image(image)
+        return image
+
+    def _generate_response(self, image: Image.Image):
+        data_uri = self._encode_image_to_data_uri(image, format="PNG")
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"{self.system_prompt}\n{self.user_prompt}",
+                    },
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                ],
+            }
+        ]
+
+        chat_response = self.client.chat.completions.create(
+            model=self.checkpoint,
+            messages=messages,
+        )
+
+        print("Chat completion output:", chat_response.choices[0].message.content)
+        return chat_response.choices[0].message.content


### PR DESCRIPTION
Added VLLM_OpenAI_Client model implementation and supporting cmdline arguments

This was tested on a 16GB 5060Ti GPU server which was running vLLM inside of Docker:
```
vllm serve NeoChen1024/llama-joycaption-beta-one-hf-llava-FP8-Dynamic --async-scheduling --tensor-parallel-size=1 --mm-encoder-tp-mode=data --limit-mm-per-prompt.video=0 --max-model-len=8192 --gpu-memory-utilization=0.8
```
Connected to via:
```
docker compose run --rm --remove-orphans vlm-caption --openai_api_base_url=http://localhost:8000/v1 --model=NeoChen1024/llama-joycaption-beta-one-hf-llava-FP8-Dynamic --system_prompt=system_prompt_basic.txt --user_prompt=user_prompt_image_quality.txt --replace_newlines
```

modifed:
- use 'host' network mode to allow connections out to vllm